### PR TITLE
Sort Icons by Amount in Icon Bar

### DIFF
--- a/MunzeeMap-Filter.js
+++ b/MunzeeMap-Filter.js
@@ -146,7 +146,9 @@ function createfilter4Map( event, xhr, settings ) {
     }
 
     //Creation
-    for ( imgSRC in iconCounter ) {
+    var iconList = Object.keys(iconCounter).sort(function(a,b){return iconCounter[b]-iconCounter[a]});
+    for ( imgSRCIndex in iconList ) {
+        imgSRC = iconList[imgSRCIndex];
         var isReporter = ( !localStorage.getItem( 'MMF' ) ? null : JSON.parse( localStorage.getItem( 'MMF' ) ).isReporter );
         let strType = imgSRC.split( '/' )[ imgSRC.split( '/' ).length - 1 ].split( '.' )[ 0 ];
         let isPhysical = ( arrPhysicals.indexOf( imgSRC ) >= 0 ? true : false );


### PR DESCRIPTION
Icons in the Icon Bar below the map will now show in order of the amount of them on the map, rather than in a seemingly-random order.